### PR TITLE
Support for Unicode surrogate pairs

### DIFF
--- a/src/blocks/ajax/conf/placeholder.txt
+++ b/src/blocks/ajax/conf/placeholder.txt
@@ -1,0 +1,1 @@
+conf dir required for successful build..

--- a/src/blocks/serializers/java/org/apache/cocoon/components/serializers/encoding/XMLEncoder.java
+++ b/src/blocks/serializers/java/org/apache/cocoon/components/serializers/encoding/XMLEncoder.java
@@ -31,6 +31,8 @@ public class XMLEncoder extends CompiledEncoder {
     private static final char ENCODE_LT[]   = "&lt;".toCharArray();
     private static final char ENCODE_GT[]   = "&gt;".toCharArray();
 
+    private Character highSurrogate = null;
+    
     /**
      * Create a new instance of this <code>XMLEncoder</code>.
      */
@@ -86,6 +88,18 @@ public class XMLEncoder extends CompiledEncoder {
      * specified character.
      */
     public char[] encode(char c) {
+        if (highSurrogate != null) {
+            if (!Character.isLowSurrogate(c)) {
+                throw new IllegalArgumentException("Expected low surrogate char");
+            }
+            int codePoint = Character.toCodePoint(highSurrogate.charValue(), c);
+            highSurrogate = null;
+            return new char[] {(char) codePoint};
+        } else if (Character.isHighSurrogate(c)) {
+            highSurrogate = Character.valueOf(c);
+            return new char[0];
+        }
+        
         switch (c) {
             case 0x22: return(ENCODE_QUOT); // (") [&quot;]
             case 0x26: return(ENCODE_AMP);  // (&) [&amp;]

--- a/src/test/org/apache/cocoon/components/serializers/encoding/XMLEncoderTest.java
+++ b/src/test/org/apache/cocoon/components/serializers/encoding/XMLEncoderTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cocoon.components.serializers.encoding;
+
+import junit.framework.TestCase;
+
+import java.util.Arrays;
+
+public class XMLEncoderTest extends TestCase {
+    
+    private XMLEncoder encoder = new XMLEncoder();
+    
+    public void testEncodingSurrogatePairs() {
+        assertTrue(encoder.encode('\uD83C').length == 0);
+        
+        assertTrue(Arrays.equals(new char[] {(char) 127808}, encoder.encode('\uDF40')));
+    }
+}

--- a/tools/targets/compile-build.xml
+++ b/tools/targets/compile-build.xml
@@ -103,6 +103,7 @@
     <path id="test.classpath">
       <path refid="classpath"/>
       <pathelement location="${build.dest}" />
+      <pathelement location="${build.blocks}/serializers/dest" />
        <!-- FIXME Resolver tests depend on deprecated stuff -->
       <pathelement location="${build.deprecated}" />
       <pathelement location="${build.test}" />


### PR DESCRIPTION
This PR adds support for encoding surrogate pairs as a single character the XMLEncoder implementation. See [COCOON-2352](https://issues.apache.org/jira/browse/COCOON-2352) for further details.
