### PR TITLE
COCOON-2360: Change the inconsistent method name.

### DIFF
--- a/blocks/cocoon-scratchpad/cocoon-scratchpad-impl/src/main/java/org/apache/cocoon/selection/DateSelector.java
+++ b/blocks/cocoon-scratchpad/cocoon-scratchpad-impl/src/main/java/org/apache/cocoon/selection/DateSelector.java
@@ -258,7 +258,7 @@ public class DateSelector extends AbstractSwitchSelector
         }
         // let SelectorContext do the work
         DateSelectorContext csc = (DateSelectorContext)selectorContext;
-        return csc.select(expression);
+        return csc.contains(expression);
     }
     
     /**
@@ -375,7 +375,7 @@ public class DateSelector extends AbstractSwitchSelector
          * @param expression a symbolic name which may match member of set
          * @return true iff expression is member of set
          */
-        public boolean select( String expression ) {
+        public boolean contains( String expression ) {
             return this.set.contains( expression );
         }
     }


### PR DESCRIPTION
The method is named as "select".
"select" is prone to mean that something will be selected.
But this method actually checks whether the expression is contained or not.
So, rename it as "contains" should be more clearly and intuitively.