### PR TITLE
use Objects.equals to avoid possible NullPointerException

### DIFF
--- a/blocks/cocoon-session-fw/cocoon-session-fw-impl/src/main/java/org/apache/cocoon/webapps/session/transformation/SessionPostTransformer.java
+++ b/blocks/cocoon-session-fw/cocoon-session-fw-impl/src/main/java/org/apache/cocoon/webapps/session/transformation/SessionPostTransformer.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Objects;
 
 import javax.servlet.http.HttpSession;
 import javax.xml.transform.OutputKeys;
@@ -320,7 +321,7 @@ public class SessionPostTransformer extends SessionPreTransformer {
             }
             DocumentFragment validationDoc = this.endRecording();
             String source = (String)stack.pop();
-            if (!source.equals("EMPTY")) {
+            if (!Objects.equals(source, "EMPTY")) {
                 // get configuration from external file
                 // referenced by "src" attribute of "validate" element
                 try {


### PR DESCRIPTION
Hello,
I found that the String "source" may cause potential risk of NullPointerException since it is immediately used after initialization. One recommended API is Objects.equals(String,String) which can avoid this exception.